### PR TITLE
DO-1383 Change run_id by id as run_id is repeated in the logs

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -36,7 +36,7 @@ def validate_origin_github():
 def process_workflow_job():
     job = request.get_json()
 
-    job_id = job["workflow_job"]["run_id"]
+    job_id = job["workflow_job"]["id"]
     workflow = job["workflow_job"]["workflow_name"]
     time_start = parse_datetime(job["workflow_job"]["started_at"])
     repository = job["repository"]["full_name"]


### PR DESCRIPTION
The problem is that for all this jobs
![Screenshot from 2023-02-01 15-07-42](https://user-images.githubusercontent.com/22884707/216065289-43016bbb-1191-4976-bb23-33b7f55238c6.png)
the run_id (job_id in our logs) is the same, so we can not distinguish which one started after or before, we must use id instead.
I have check that id is the same across the different states, `queue`, `in_progress`...