### PR TITLE
Ignore if in progress before queued

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,7 +75,7 @@ def process_workflow_job():
         job_requested = jobs.get(job_id)
         time_to_start = None
         if not job_requested:
-            app.logger.error(f"Job {job_id} is {action} but not stored!")
+            app.logger.warning(f"Job {job_id} is {action} but not stored!")
         else:
             if time_start < datetime.fromtimestamp(job_requested):
                 app.logger.error(f"Job {job_id} was in progress before being queued")

--- a/src/app.py
+++ b/src/app.py
@@ -98,7 +98,7 @@ def process_workflow_job():
     elif action == "completed":
         job_requested = jobs.get(job_id)
         if not job_requested:
-            app.logger.error(f"Job {job_id} is {action} but not stored!")
+            app.logger.warning(f"Job {job_id} is {action} but not stored!")
             time_to_finish = 0
         else:
             time_to_finish = (


### PR DESCRIPTION
Due to a bug with github webhooks, occasionally  the in progress date is before the queued date, as you can see in the following example.

```{
  "action": "in_progress",
  "workflow_job": {
    "id": 11410137540,
    "run_id": 4201434196,
    "workflow_name": "Main CI",
    "head_branch": "ape/wasm-log/enable-logging",
    "run_url": "https://api.github.com/repos/midokura/evp-device-agent/actions/runs/4201434196",
    "run_attempt": 1,
    "node_id": "CR_kwDODoNrLs8AAAACqBjhxA",
    "head_sha": "3645b32e8addf1d011a267fde04584cb0cc81fe4",
    "url": "https://api.github.com/repos/midokura/evp-device-agent/actions/jobs/11410137540",
    "html_url": "https://github.com/midokura/evp-device-agent/actions/runs/4201434196/jobs/7288440127",
    "status": "in_progress",
    "conclusion": null,
    "started_at": "2023-02-17T06:57:46Z",```

{
  "action": "queued",
  "workflow_job": {
    "id": 11410137540,
    "run_id": 4201434196,
    "workflow_name": "Main CI",
    "head_branch": "ape/wasm-log/enable-logging",
    "run_url": "https://api.github.com/repos/midokura/evp-device-agent/actions/runs/4201434196",
    "run_attempt": 1,
    "node_id": "CR_kwDODoNrLs8AAAACqBjhxA",
    "head_sha": "3645b32e8addf1d011a267fde04584cb0cc81fe4",
    "url": "https://api.github.com/repos/midokura/evp-device-agent/actions/jobs/11410137540",
    "html_url": "https://github.com/midokura/evp-device-agent/actions/runs/4201434196/jobs/7288440127",
    "status": "queued",
    "conclusion": null,
    "started_at": "2023-02-17T06:57:48Z",
```

due to that, I think the best option is to ignore this errors that not frequent.
Also I'm deleting time_to_start from the logs so it doesn't count for the metrics.
