### PR TITLE
fix: improvements in monitor queued jobs

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -133,7 +133,7 @@ def monitor_queued_jobs():
 
     queued_jobs = [job for job in jobs if job.action == "queued"]
     job = min(queued_jobs, key=lambda x: x.time_start)
-    delay = int(datetime.now().timestamp() - job.time_start)
+    delay = (datetime.now() - job.time_start).seconds
 
     if delay <= int(os.getenv("QUEUED_JOBS_DELAY_THRESHOLD", 150)):
         return

--- a/src/app.py
+++ b/src/app.py
@@ -23,6 +23,7 @@ loglevel_flask = os.getenv("LOGLEVEL", "INFO")
 if hasattr(logging, loglevel_flask):
     loglevel_flask = getattr(logging, loglevel_flask)
     log.setLevel(loglevel_flask)
+logging.getLogger('apscheduler.executors.default').setLevel(logging.WARNING)
 
 jobs = dict()
 

--- a/src/app.py
+++ b/src/app.py
@@ -131,7 +131,8 @@ def monitor_queued_jobs():
     if not jobs:
         return
 
-    job = min(jobs.values(), key=lambda x: x.time_start if x.action == "queued")
+    queued_jobs = [job for job in jobs if job.action == "queued"]
+    job = min(queued_jobs, key=lambda x: x.time_start)
     delay = int(datetime.now().timestamp() - job.time_start)
 
     if delay <= int(os.getenv("QUEUED_JOBS_DELAY_THRESHOLD", 150)):

--- a/src/app.py
+++ b/src/app.py
@@ -9,7 +9,7 @@ from flask_apscheduler import APScheduler
 
 from const import GithubHeaders, LOGGING_CONFIG
 from github import GithubJob
-from utils import parse_datetime, dict_to_logfmt
+from utils import dict_to_logfmt
 
 dictConfig(LOGGING_CONFIG)
 
@@ -126,7 +126,7 @@ def process_workflow_job():
 
 @scheduler.task('interval', id='monitor_queued', seconds=30)
 def monitor_queued_jobs():
-    """ Return the job that has been queued and not starting for long time. """
+    """Return the job that has been queued and not starting for long time."""
     app.logger.debug("Starting monitor_queued_jobs")
     if not jobs:
         return

--- a/src/app.py
+++ b/src/app.py
@@ -142,7 +142,7 @@ def monitor_queued_jobs():
         return
 
     job_id, time_start = min(jobs.items(), key=lambda x: x[1])
-    delay = datetime.now().timestamp() - time_start
+    delay = int(datetime.now().timestamp() - time_start)
 
     if delay <= int(os.getenv("QUEUED_JOBS_DELAY_THRESHOLD", 150)):
         return

--- a/src/github.py
+++ b/src/github.py
@@ -1,0 +1,76 @@
+from utils import parse_datetime
+
+class GithubJob():
+    def __init__(self, json_body: str):
+        self.data = json_body
+
+    @property
+    def id(self):
+        return self.data["workflow_job"]["id"]
+
+    @property
+    def job_id(self):
+        return self.id
+
+    @property
+    def run_id(self):
+        return self.data["workflow_job"]["run_id"]
+
+    @property
+    def name(self):
+        return self.data["workflow_job"]["name"].replace("\n", " ")
+
+    @property
+    def job_name(self):
+        return self.name
+
+    @property
+    def workflow(self):
+        return self.data["workflow_job"]["workflow_name"]
+
+    @property
+    def time_start(self):
+        return parse_datetime(self.data["workflow_job"]["started_at"])
+
+    @property
+    def time_completed(self):
+        return parse_datetime(self.data["workflow_job"]["completed_at"])
+
+    @property
+    def branch(self):
+        return self.data["workflow_job"].get("head_branch", "")
+
+    @property
+    def repository(self):
+        return self.data["repository"]["full_name"]
+
+    @property
+    def repository_private(self):
+        return self.data["repository"]["private"]
+
+    @property
+    def action(self):
+        return self.data["action"]
+
+    @property
+    def conclusion(self):
+        return self.data["workflow_job"].get("conclusion")
+
+    @property
+    def requestor(self):
+        return self.data.get("sender", {}).get("login")
+
+    @property
+    def runner_name(self):
+        return self.data["workflow_job"]["runner_name"]
+
+    @property
+    def runner_group_name(self):
+        return self.data["workflow_job"]["runner_group_name"]
+
+    @property
+    def runner_public(self):
+        return self.runner_group_name == "GitHub Actions"
+
+    def __str__(self):
+        return f"<{self.id}@{self.name}>"

--- a/src/github.py
+++ b/src/github.py
@@ -1,5 +1,6 @@
 from utils import parse_datetime
 
+
 class GithubJob():
     def __init__(self, json_body: str):
         self.data = json_body


### PR DESCRIPTION
Queued jobs was picking latest "stored" job, which does not match with `queued` action we're looking for, as it would later run `in_progress` but not changed internally.

In order to properly have the job details and check for `queued` jobs, a refactor is included, and the whole object with full details is stored in memory, deleted after the GitHub job is `completed`.