### PR TITLE
If checkSuite is completed, we should stop tracking the queued job

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
   - id: check-docstring-first

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,6 @@ repos:
   - id: check-yaml
   - id: debug-statements
   - id: end-of-file-fixer
-- repo: https://github.com/myint/docformatter
-  rev: v1.7.5
-  hooks:
-  - id: docformatter
-    args: [--in-place]
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.15.2
   hooks:

--- a/src/app.py
+++ b/src/app.py
@@ -137,7 +137,7 @@ def monitor_jobs():
         for job_data in jobs_data["nodes"]:
             job = job_handler.queued.get(job_data["id"])
             if (
-                job.get("checkSuite", {}).get("status") == "COMPLETED"
+                job_data.get("checkSuite", {}).get("status") == "COMPLETED"
                 or job_data["status"] != "QUEUED"
             ):
                 job = job_handler.queued.pop(job_data["id"], None)

--- a/src/app.py
+++ b/src/app.py
@@ -136,7 +136,10 @@ def monitor_jobs():
 
         for job_data in jobs_data["nodes"]:
             job = job_handler.queued.get(job_data["id"])
-            if job_data["status"] != "QUEUED":
+            if (
+                job.get("checkSuite", {}).get("status") == "COMPLETED"
+                or job_data["status"] != "QUEUED"
+            ):
                 job = job_handler.queued.pop(job_data["id"], None)
                 app.logger.info(
                     f"Job {job_data['id']} is no longer queued {job_data['status']}"

--- a/src/query_graphql.py
+++ b/src/query_graphql.py
@@ -32,6 +32,7 @@ def query_jobs(node_id_list: List[str]):
                   name
                 }
                 checkSuite {
+                  status
                   workflowRun {
                     event
                     runNumber

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -68,14 +68,14 @@ def test_monitor_jobs(
             {
                 "id": "workflow_id_queued",
                 "status": "QUEUED",
-                "checkSuit": {"status": "IN_PROGRESS"},
+                "checkSuite": {"status": "IN_PROGRESS"},
                 "startedAt": "2024-04-29T12:43:16Z",
                 "completedAt": None,
             },
             {
                 "id": "workflow_id_in_progress",
                 "status": "IN_PROGRESS",
-                "checkSuit": {"status": "IN_PROGRESS"},
+                "checkSuite": {"status": "IN_PROGRESS"},
                 "startedAt": "2024-04-29T12:43:32Z",
                 "completedAt": None,
             },
@@ -105,7 +105,7 @@ def test_monitor_jobs_completed_suit(
             {
                 "id": "workflow_id_queued",
                 "status": "QUEUED",
-                "checkSuit": {"status": "COMPLETED"},
+                "checkSuite": {"status": "COMPLETED"},
                 "startedAt": "2024-04-29T12:43:16Z",
                 "completedAt": None,
             }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -68,12 +68,14 @@ def test_monitor_jobs(
             {
                 "id": "workflow_id_queued",
                 "status": "QUEUED",
+                "checkSuit": {"status": "IN_PROGRESS"},
                 "startedAt": "2024-04-29T12:43:16Z",
                 "completedAt": None,
             },
             {
                 "id": "workflow_id_in_progress",
                 "status": "IN_PROGRESS",
+                "checkSuit": {"status": "IN_PROGRESS"},
                 "startedAt": "2024-04-29T12:43:32Z",
                 "completedAt": None,
             },
@@ -85,4 +87,32 @@ def test_monitor_jobs(
     assert "workflow_id_in_progress" not in app.job_handler.queued
     assert in_progress_job.status == "in_progress"
     assert in_progress_job.in_progress_at is not None
+    send_queued_metric_mock.assert_called()
+
+
+@patch("jobs.Job.send_queued_metric")
+@patch("app.query_jobs")
+def test_monitor_jobs_completed_suit(
+    query_jobs_mock, send_queued_metric_mock, queued_job
+):
+    app.job_handler = JobEventsHandler()
+    app.job_handler.queued = {
+        "workflow_id_queued": queued_job,
+    }
+
+    query_jobs_mock.return_value = {
+        "nodes": [
+            {
+                "id": "workflow_id_queued",
+                "status": "QUEUED",
+                "checkSuit": {"status": "COMPLETED"},
+                "startedAt": "2024-04-29T12:43:16Z",
+                "completedAt": None,
+            }
+        ]
+    }
+
+    monitor_jobs()
+
+    assert "workflow_id_queued" not in app.job_handler.queued
     send_queued_metric_mock.assert_called()


### PR DESCRIPTION
DO-3186

Sometimes jobs get stuck in the status "QUEUED" and github just don't update them. We need to check if the checkSuite status is completed, and if it is we can assume that the job status will never be updated again.

In the PR I also remove the pre-commit check docformatter as it is bugged and it makes the pre-commit fail. https://github.com/PyCQA/docformatter/pull/287